### PR TITLE
Remove :focus state after copying

### DIFF
--- a/src/ngClip.js
+++ b/src/ngClip.js
@@ -72,6 +72,7 @@
               if (angular.isDefined(attrs.clipClick)) {
                 scope.$apply(scope.clipClick);
               }
+              element.blur();
             });
 
             scope.$on('$destroy', function() {


### PR DESCRIPTION
Whether by ZeroClipboard design or nature of ng-clip, the focus state does not seem to be removed from an element after copying. Can be fixed by hooking into aftercopy event and calling `blur()`.